### PR TITLE
Fixes an issue where related data was not correctly frozen

### DIFF
--- a/src/Model/Behavior/PersistRelatedDataBehavior.php
+++ b/src/Model/Behavior/PersistRelatedDataBehavior.php
@@ -38,11 +38,12 @@ class PersistRelatedDataBehavior extends Behavior
                 throw new Exception(sprintf('Incorrect definition of related data to persist for %s', $mapped));
             }
 
-            $foreign = $entity->get($this->_table->{$mappedTable}->foreignKey());
+            $foreignKeys = $entity->extract((array)$this->_table->{$mappedTable}->foreignKey());
+            $dirtyForeignKeys = $entity->extract((array)$this->_table->{$mappedTable}->foreignKey(), true);
 
-            if (!is_null($foreign)) {
+            if (!empty($dirtyForeignKeys)) {
                 // get related entity
-                $related = $this->_table->{$mappedTable}->get($foreign);
+                $related = $this->_table->{$mappedTable}->get($foreignKeys);
 
                 // set field value
                 $entity->set($field, $related->get($mappedField));

--- a/tests/Fixture/InvoicesFixture.php
+++ b/tests/Fixture/InvoicesFixture.php
@@ -27,6 +27,7 @@ class InvoicesFixture extends TestFixture
 {
     public $fields = [
         'id' => ['type' => 'integer'],
+        'a_field' => ['type' => 'string', 'default' => null, 'null' => true],
         'contact_id' => ['type' => 'integer', 'default' => null, 'null' => true],
         'contact_name' => ['type' => 'string', 'default' => null, 'null' => true],
         'contact_address' => ['type' => 'string', 'default' => null, 'null' => true],

--- a/tests/TestCase/Model/Behavior/PersistRelatedDataBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/PersistRelatedDataBehaviorTest.php
@@ -73,12 +73,15 @@ class PersistRelatedDataBehaviorTest extends TestCase
 
         // no change
         $invoice = $this->Invoices->get(1);
+        $invoice->a_field = 'test';
         $this->Invoices->save($invoice);
 
         $this->assertEquals('First name', $invoice->contact_name);
 
         // change fields
+        $invoice = $this->Invoices->get(1);
         $invoice->contact_id = 2;
+        $invoice->a_field = 'test';
         $this->Invoices->save($invoice);
 
         $this->assertEquals('Second name', $invoice->contact_name);


### PR DESCRIPTION
If changing a child record, and then saving the master record again the persisted data was overwritten. The tests did not catch this as no save on `Invoice` was actually performed.
